### PR TITLE
241106 Feat: 과제 1-1 구현:: AlarmClock 매커니즘 변경

### DIFF
--- a/include/threads/thread.h
+++ b/include/threads/thread.h
@@ -87,13 +87,13 @@ typedef int tid_t;
  * blocked state is on a semaphore wait list. */
 struct thread {
 	/* Owned by thread.c. */
-	tid_t tid;                          /* Thread identifier. */
-	enum thread_status status;          /* Thread state. */
-	char name[16];                      /* Name (for debugging purposes). */
-	int priority;                       /* Priority. */
-
+	tid_t tid;                          /* 스레드 식별자. */
+	enum thread_status status;          /* 스레드 상태. */
+	char name[16];                      /* 이름 (디버깅 용도). */
+	int priority;                       /* 우선순위. */
+	int64_t wakeup_ticks;                /* 깨어날 시간. */
 	/* Shared between thread.c and synch.c. */
-	struct list_elem elem;              /* List element. */
+	struct list_elem elem;              /* 리스트 요소. */
 
 #ifdef USERPROG
 	/* Owned by userprog/process.c. */
@@ -132,6 +132,9 @@ const char *thread_name (void);
 
 void thread_exit (void) NO_RETURN;
 void thread_yield (void);
+void thread_sleep(int64_t ticks);
+void thread_awake(int64_t ticks);
+bool compare_wakeup_ticks(const struct list_elem *a, const struct list_elem *b, void *aux);
 
 int thread_get_priority (void);
 void thread_set_priority (int);


### PR DESCRIPTION
PintOS Project week1 Subject 1-01 AlarmClock 변경 완료

# init.c
* PintOS 구현 제일 첫 진입점인 main 함수에 대한 주석 일부 추가
  * 특히 스레드의 초기화, 시작, 종료에 관한 함수들에 대해 추가 주석 작성

# thread.c
* 기존에 Busy-Waiting 방식으로 구현되어 있던 AlarmClock에 대해 Sleep-Awake 방식으로 변경 완료

* thread_sleep, thread_awake, compare_wakeup_ticks 함수 구현
  * `thread_sleep()`
    * 실행 중인 스레드를 유휴상태로 돌리고, 일정 시간 후 깨어나게 만든다.
    * 현재 실행 중인 스레드가 idle_thread인지 확인하고 난 뒤, 일어날 시간을 저장하고 sleep_list에 추가한다.
    * 이후 깨어나기 전까지 block 상태에 빠지도록 만든다. timer_sleep() 함수에서 주로 호출될 예정이다.
  * `thread_awake()`
    * ticks(현재 시간)에 따라 깨어나야 할 스레드들을 깨운다. sleep_list에서 wakeup_ticks(깨어날 시간)이 현재 시간보다 작거나 같은 스레드들을 찾아 sleep_list에서 제거하고 THREAD_READY 상태로 변경한다.
    * 이때 sleep_list에 담긴 스레드들은 오름차순으로 정렬되어 있고, 더 이상 깨울 스레드가 없다고 판단되면 순회를 종료한다.
    * 이 함수는 매 타이머 인터럽트마다 호출되며, 인터럽트가 비활성화된 상태에서만 호출할 수 있다.
  * `compare_wakeup_ticks()`
    * 스레드를 유휴상태로 만들기 위해 해당 스레드를 sleep_list에 삽입하는 과정에서 적절한 위치를 찾아 삽입할 때 작동하는 함수다.
    * 현재 선택된 스레드와 삽입하려는 스레드의 wakeup_ticks를 비교하여 위치를 잡는다.

# timer.c
* sleep-awake 방식으로의 수정을 위한 timer_sleep, timer_interrupt 함수 수정

  * `timer_sleep()`
    * 기존 코드의 thread_yield() 함수를 호출하면 작업 중이던 스레드가 ready_list에 삽입되며 block 상태가 아닌 ready 상태에서 호출을 기다림.
    * 이로 인해 매 탐색 시마다 방해요인으로 작용해 비효율의 원인으로 작용함
    * thraed_sleep() 함수를 호출하는 방향으로 수정하여 sleep_list에 삽입하는 방식으로 변경
  * `timer_iinterrupt()`
    * ticks를 증가시키고 특정 시점에 깨어나야 할 스레드들을 깨어나도록 만드는 로직으로 변경