### PR TITLE
Gshduet/pj01

### DIFF
--- a/include/lib/kernel/list.h
+++ b/include/lib/kernel/list.h
@@ -77,7 +77,7 @@
  *
  * - "interior element": An element that is not the head or
  * tail, that is, a real list element.  An empty list does
- * not have any interior elements.*/
+ * not have any interior elements. */
 
 #include <stdbool.h>
 #include <stddef.h>
@@ -95,11 +95,9 @@ struct list {
 	struct list_elem tail;      /* List tail. */
 };
 
-/* Converts pointer to list element LIST_ELEM into a pointer to
-   the structure that LIST_ELEM is embedded inside.  Supply the
-   name of the outer structure STRUCT and the member name MEMBER
-   of the list element.  See the big comment at the top of the
-   file for an example. */
+/* LIST_ELEM 포인터를 해당 리스트 요소가 포함된 구조체의 포인터로 변환합니다.
+   외부 구조체의 이름 STRUCT와 리스트 요소의 멤버 이름 MEMBER를 제공해야 합니다.
+   사용 예시는 파일 상단의 큰 주석을 참조하세요. */
 #define list_entry(LIST_ELEM, STRUCT, MEMBER)           \
 	((STRUCT *) ((uint8_t *) &(LIST_ELEM)->next     \
 		- offsetof (STRUCT, MEMBER.next)))

--- a/include/threads/synch.h
+++ b/include/threads/synch.h
@@ -6,43 +6,43 @@
 
 /* A counting semaphore. */
 struct semaphore {
-	unsigned value;             /* Current value. */
-	struct list waiters;        /* List of waiting threads. */
+    unsigned value;      /* Current value. */
+    struct list waiters; /* List of waiting threads. */
 };
 
-void sema_init (struct semaphore *, unsigned value);
-void sema_down (struct semaphore *);
-bool sema_try_down (struct semaphore *);
-void sema_up (struct semaphore *);
-void sema_self_test (void);
+void sema_init(struct semaphore *, unsigned value);
+void sema_down(struct semaphore *);
+bool sema_try_down(struct semaphore *);
+void sema_up(struct semaphore *);
+void sema_self_test(void);
 
 /* Lock. */
 struct lock {
-	struct thread *holder;      /* Thread holding lock (for debugging). */
-	struct semaphore semaphore; /* Binary semaphore controlling access. */
+    struct thread *holder;      /* Thread holding lock (for debugging). */
+    struct semaphore semaphore; /* Binary semaphore controlling access. */
 };
 
-void lock_init (struct lock *);
-void lock_acquire (struct lock *);
-bool lock_try_acquire (struct lock *);
-void lock_release (struct lock *);
-bool lock_held_by_current_thread (const struct lock *);
+void lock_init(struct lock *);
+void lock_acquire(struct lock *);
+bool lock_try_acquire(struct lock *);
+void lock_release(struct lock *);
+bool lock_held_by_current_thread(const struct lock *);
 
 /* Condition variable. */
 struct condition {
-	struct list waiters;        /* List of waiting threads. */
+    struct list waiters; /* List of waiting threads. */
 };
 
-void cond_init (struct condition *);
-void cond_wait (struct condition *, struct lock *);
-void cond_signal (struct condition *, struct lock *);
-void cond_broadcast (struct condition *, struct lock *);
+void cond_init(struct condition *);
+void cond_wait(struct condition *, struct lock *);
+void cond_signal(struct condition *, struct lock *);
+void cond_broadcast(struct condition *, struct lock *);
 
 /* Optimization barrier.
  *
  * The compiler will not reorder operations across an
  * optimization barrier.  See "Optimization Barriers" in the
  * reference guide for more information.*/
-#define barrier() asm volatile ("" : : : "memory")
+#define barrier() asm volatile("" : : : "memory")
 
 #endif /* threads/synch.h */

--- a/include/threads/thread.h
+++ b/include/threads/thread.h
@@ -1,32 +1,31 @@
 #ifndef THREADS_THREAD_H
 #define THREADS_THREAD_H
 
+#include "threads/interrupt.h"
 #include <debug.h>
 #include <list.h>
 #include <stdint.h>
-#include "threads/interrupt.h"
 #ifdef VM
 #include "vm/vm.h"
 #endif
 
-
 /* States in a thread's life cycle. */
 enum thread_status {
-	THREAD_RUNNING,     /* Running thread. */
-	THREAD_READY,       /* Not running but ready to run. */
-	THREAD_BLOCKED,     /* Waiting for an event to trigger. */
-	THREAD_DYING        /* About to be destroyed. */
+    THREAD_RUNNING, /* Running thread. */
+    THREAD_READY,   /* Not running but ready to run. */
+    THREAD_BLOCKED, /* Waiting for an event to trigger. */
+    THREAD_DYING    /* About to be destroyed. */
 };
 
 /* Thread identifier type.
    You can redefine this to whatever type you like. */
 typedef int tid_t;
-#define TID_ERROR ((tid_t) -1)          /* Error value for tid_t. */
+#define TID_ERROR ((tid_t) - 1) /* Error value for tid_t. */
 
 /* Thread priorities. */
-#define PRI_MIN 0                       /* Lowest priority. */
-#define PRI_DEFAULT 31                  /* Default priority. */
-#define PRI_MAX 63                      /* Highest priority. */
+#define PRI_MIN 0      /* Lowest priority. */
+#define PRI_DEFAULT 31 /* Default priority. */
+#define PRI_MAX 63     /* Highest priority. */
 
 /* A kernel thread or user process.
  *
@@ -86,27 +85,27 @@ typedef int tid_t;
  * ready state is on the run queue, whereas only a thread in the
  * blocked state is on a semaphore wait list. */
 struct thread {
-	/* Owned by thread.c. */
-	tid_t tid;                          /* 스레드 식별자. */
-	enum thread_status status;          /* 스레드 상태. */
-	char name[16];                      /* 이름 (디버깅 용도). */
-	int priority;                       /* 우선순위. */
-	int64_t wakeup_ticks;                /* 깨어날 시간. */
-	/* Shared between thread.c and synch.c. */
-	struct list_elem elem;              /* 리스트 요소. */
+    /* Owned by thread.c. */
+    tid_t tid;                 /* 스레드 식별자. */
+    enum thread_status status; /* 스레드 상태. */
+    char name[16];             /* 이름 (디버깅 용도). */
+    int priority;              /* 우선순위. */
+    int64_t wakeup_ticks;      /* 깨어날 시간. */
+    /* Shared between thread.c and synch.c. */
+    struct list_elem elem; /* 리스트 요소. */
 
 #ifdef USERPROG
-	/* Owned by userprog/process.c. */
-	uint64_t *pml4;                     /* Page map level 4 */
+    /* Owned by userprog/process.c. */
+    uint64_t *pml4; /* Page map level 4 */
 #endif
 #ifdef VM
-	/* Table for whole virtual memory owned by thread. */
-	struct supplemental_page_table spt;
+    /* Table for whole virtual memory owned by thread. */
+    struct supplemental_page_table spt;
 #endif
 
-	/* Owned by thread.c. */
-	struct intr_frame tf;               /* Information for switching */
-	unsigned magic;                     /* Detects stack overflow. */
+    /* Owned by thread.c. */
+    struct intr_frame tf; /* Information for switching */
+    unsigned magic;       /* Detects stack overflow. */
 };
 
 /* If false (default), use round-robin scheduler.
@@ -114,38 +113,38 @@ struct thread {
    Controlled by kernel command-line option "-o mlfqs". */
 extern bool thread_mlfqs;
 
-void thread_init (void);
-void thread_start (void);
+void thread_init(void);
+void thread_start(void);
 
-void thread_tick (void);
-void thread_print_stats (void);
+void thread_tick(void);
+void thread_print_stats(void);
 
-typedef void thread_func (void *aux);
-tid_t thread_create (const char *name, int priority, thread_func *, void *);
+typedef void thread_func(void *aux);
+tid_t thread_create(const char *name, int priority, thread_func *, void *);
 
-void thread_block (void);
-void thread_unblock (struct thread *);
+void thread_block(void);
+void thread_unblock(struct thread *);
 
-struct thread *thread_current (void);
-tid_t thread_tid (void);
-const char *thread_name (void);
+struct thread *thread_current(void);
+tid_t thread_tid(void);
+const char *thread_name(void);
 
-void thread_exit (void) NO_RETURN;
-void thread_yield (void);
+void thread_exit(void) NO_RETURN;
+void thread_yield(void);
 void thread_sleep(int64_t ticks);
 void thread_awake(int64_t ticks);
 bool compare_wakeup_ticks(const struct list_elem *a, const struct list_elem *b, void *aux);
 bool compare_priority(const struct list_elem *a, const struct list_elem *b, void *aux);
 void thread_preemption(void);
 
-int thread_get_priority (void);
-void thread_set_priority (int);
+int thread_get_priority(void);
+void thread_set_priority(int);
 
-int thread_get_nice (void);
-void thread_set_nice (int);
-int thread_get_recent_cpu (void);
-int thread_get_load_avg (void);
+int thread_get_nice(void);
+void thread_set_nice(int);
+int thread_get_recent_cpu(void);
+int thread_get_load_avg(void);
 
-void do_iret (struct intr_frame *tf);
+void do_iret(struct intr_frame *tf);
 
 #endif /* threads/thread.h */

--- a/include/threads/thread.h
+++ b/include/threads/thread.h
@@ -135,6 +135,8 @@ void thread_yield (void);
 void thread_sleep(int64_t ticks);
 void thread_awake(int64_t ticks);
 bool compare_wakeup_ticks(const struct list_elem *a, const struct list_elem *b, void *aux);
+bool compare_priority(const struct list_elem *a, const struct list_elem *b, void *aux);
+void thread_preemption(void);
 
 int thread_get_priority (void);
 void thread_set_priority (int);

--- a/lib/kernel/list.c
+++ b/lib/kernel/list.c
@@ -31,52 +31,41 @@
    elements allows us to do a little bit of checking on some
    operations, which can be valuable.) */
 
-static bool is_sorted (struct list_elem *a, struct list_elem *b,
-		list_less_func *less, void *aux) UNUSED;
+static bool is_sorted(struct list_elem *a, struct list_elem *b, list_less_func *less, void *aux) UNUSED;
 
 /* Returns true if ELEM is a head, false otherwise. */
-static inline bool
-is_head (struct list_elem *elem) {
-	return elem != NULL && elem->prev == NULL && elem->next != NULL;
-}
+static inline bool is_head(struct list_elem *elem) { return elem != NULL && elem->prev == NULL && elem->next != NULL; }
 
 /* Returns true if ELEM is an interior element,
    false otherwise. */
-static inline bool
-is_interior (struct list_elem *elem) {
-	return elem != NULL && elem->prev != NULL && elem->next != NULL;
+static inline bool is_interior(struct list_elem *elem) {
+    return elem != NULL && elem->prev != NULL && elem->next != NULL;
 }
 
 /* Returns true if ELEM is a tail, false otherwise. */
-static inline bool
-is_tail (struct list_elem *elem) {
-	return elem != NULL && elem->prev != NULL && elem->next == NULL;
-}
+static inline bool is_tail(struct list_elem *elem) { return elem != NULL && elem->prev != NULL && elem->next == NULL; }
 
 /* Initializes LIST as an empty list. */
-void
-list_init (struct list *list) {
-	ASSERT (list != NULL);
-	list->head.prev = NULL;
-	list->head.next = &list->tail;
-	list->tail.prev = &list->head;
-	list->tail.next = NULL;
+void list_init(struct list *list) {
+    ASSERT(list != NULL);
+    list->head.prev = NULL;
+    list->head.next = &list->tail;
+    list->tail.prev = &list->head;
+    list->tail.next = NULL;
 }
 
 /* Returns the beginning of LIST.  */
-struct list_elem *
-list_begin (struct list *list) {
-	ASSERT (list != NULL);
-	return list->head.next;
+struct list_elem *list_begin(struct list *list) {
+    ASSERT(list != NULL);
+    return list->head.next;
 }
 
 /* Returns the element after ELEM in its list.  If ELEM is the
    last element in its list, returns the list tail.  Results are
    undefined if ELEM is itself a list tail. */
-struct list_elem *
-list_next (struct list_elem *elem) {
-	ASSERT (is_head (elem) || is_interior (elem));
-	return elem->next;
+struct list_elem *list_next(struct list_elem *elem) {
+    ASSERT(is_head(elem) || is_interior(elem));
+    return elem->next;
 }
 
 /* Returns LIST's tail.
@@ -84,27 +73,24 @@ list_next (struct list_elem *elem) {
    list_end() is often used in iterating through a list from
    front to back.  See the big comment at the top of list.h for
    an example. */
-struct list_elem *
-list_end (struct list *list) {
-	ASSERT (list != NULL);
-	return &list->tail;
+struct list_elem *list_end(struct list *list) {
+    ASSERT(list != NULL);
+    return &list->tail;
 }
 
 /* Returns the LIST's reverse beginning, for iterating through
    LIST in reverse order, from back to front. */
-struct list_elem *
-list_rbegin (struct list *list) {
-	ASSERT (list != NULL);
-	return list->tail.prev;
+struct list_elem *list_rbegin(struct list *list) {
+    ASSERT(list != NULL);
+    return list->tail.prev;
 }
 
 /* Returns the element before ELEM in its list.  If ELEM is the
    first element in its list, returns the list head.  Results are
    undefined if ELEM is itself a list head. */
-struct list_elem *
-list_prev (struct list_elem *elem) {
-	ASSERT (is_interior (elem) || is_tail (elem));
-	return elem->prev;
+struct list_elem *list_prev(struct list_elem *elem) {
+    ASSERT(is_interior(elem) || is_tail(elem));
+    return elem->prev;
 }
 
 /* Returns LIST's head.
@@ -120,10 +106,9 @@ list_prev (struct list_elem *elem) {
    ...do something with f...
    }
    */
-struct list_elem *
-list_rend (struct list *list) {
-	ASSERT (list != NULL);
-	return &list->head;
+struct list_elem *list_rend(struct list *list) {
+    ASSERT(list != NULL);
+    return &list->head;
 }
 
 /* Return's LIST's head.
@@ -137,71 +122,59 @@ list_rend (struct list *list) {
    ...
    }
    */
-struct list_elem *
-list_head (struct list *list) {
-	ASSERT (list != NULL);
-	return &list->head;
+struct list_elem *list_head(struct list *list) {
+    ASSERT(list != NULL);
+    return &list->head;
 }
 
 /* Return's LIST's tail. */
-struct list_elem *
-list_tail (struct list *list) {
-	ASSERT (list != NULL);
-	return &list->tail;
+struct list_elem *list_tail(struct list *list) {
+    ASSERT(list != NULL);
+    return &list->tail;
 }
 
-/* Inserts ELEM just before BEFORE, which may be either an
-   interior element or a tail.  The latter case is equivalent to
-   list_push_back(). */
-void
-list_insert (struct list_elem *before, struct list_elem *elem) {
-	ASSERT (is_interior (before) || is_tail (before));
-	ASSERT (elem != NULL);
+/* ELEM을 BEFORE 바로 앞에 삽입합니다. BEFORE는 내부 요소이거나 tail일 수 있습니다.
+   BEFORE가 tail인 경우는 list_push_back()과 동일한 동작을 수행합니다. */
+void list_insert(struct list_elem *before, struct list_elem *elem) {
+    ASSERT(is_interior(before) || is_tail(before)); // before가 내부 요소이거나 tail일 수 있음
+    ASSERT(elem != NULL);                           // elem이 NULL이 아님
 
-	elem->prev = before->prev;
-	elem->next = before;
-	before->prev->next = elem;
-	before->prev = elem;
+    elem->prev = before->prev; // elem의 prev를 before의 prev로 설정
+    elem->next = before;       // elem의 next를 before로 설정
+    before->prev->next = elem; // before의 prev의 next를 elem로 설정
+    before->prev = elem;       // before의 prev를 elem로 설정
 }
 
 /* Removes elements FIRST though LAST (exclusive) from their
    current list, then inserts them just before BEFORE, which may
    be either an interior element or a tail. */
-void
-list_splice (struct list_elem *before,
-		struct list_elem *first, struct list_elem *last) {
-	ASSERT (is_interior (before) || is_tail (before));
-	if (first == last)
-		return;
-	last = list_prev (last);
+void list_splice(struct list_elem *before, struct list_elem *first, struct list_elem *last) {
+    ASSERT(is_interior(before) || is_tail(before));
+    if (first == last)
+        return;
+    last = list_prev(last);
 
-	ASSERT (is_interior (first));
-	ASSERT (is_interior (last));
+    ASSERT(is_interior(first));
+    ASSERT(is_interior(last));
 
-	/* Cleanly remove FIRST...LAST from its current list. */
-	first->prev->next = last->next;
-	last->next->prev = first->prev;
+    /* Cleanly remove FIRST...LAST from its current list. */
+    first->prev->next = last->next;
+    last->next->prev = first->prev;
 
-	/* Splice FIRST...LAST into new list. */
-	first->prev = before->prev;
-	last->next = before;
-	before->prev->next = first;
-	before->prev = last;
+    /* Splice FIRST...LAST into new list. */
+    first->prev = before->prev;
+    last->next = before;
+    before->prev->next = first;
+    before->prev = last;
 }
 
 /* Inserts ELEM at the beginning of LIST, so that it becomes the
    front in LIST. */
-void
-list_push_front (struct list *list, struct list_elem *elem) {
-	list_insert (list_begin (list), elem);
-}
+void list_push_front(struct list *list, struct list_elem *elem) { list_insert(list_begin(list), elem); }
 
 /* Inserts ELEM at the end of LIST, so that it becomes the
    back in LIST. */
-void
-list_push_back (struct list *list, struct list_elem *elem) {
-	list_insert (list_end (list), elem);
-}
+void list_push_back(struct list *list, struct list_elem *elem) { list_insert(list_end(list), elem); }
 
 /* Removes ELEM from its list and returns the element that
    followed it.  Undefined behavior if ELEM is not in a list.
@@ -237,97 +210,84 @@ struct list_elem *e = list_pop_front (&list);
 ...do something with e...
 }
 */
-struct list_elem *
-list_remove (struct list_elem *elem) {
-	ASSERT (is_interior (elem));
-	elem->prev->next = elem->next;
-	elem->next->prev = elem->prev;
-	return elem->next;
+struct list_elem *list_remove(struct list_elem *elem) {
+    ASSERT(is_interior(elem));
+    elem->prev->next = elem->next;
+    elem->next->prev = elem->prev;
+    return elem->next;
 }
 
 /* Removes the front element from LIST and returns it.
    Undefined behavior if LIST is empty before removal. */
-struct list_elem *
-list_pop_front (struct list *list) {
-	struct list_elem *front = list_front (list);
-	list_remove (front);
-	return front;
+struct list_elem *list_pop_front(struct list *list) {
+    struct list_elem *front = list_front(list);
+    list_remove(front);
+    return front;
 }
 
 /* Removes the back element from LIST and returns it.
    Undefined behavior if LIST is empty before removal. */
-struct list_elem *
-list_pop_back (struct list *list) {
-	struct list_elem *back = list_back (list);
-	list_remove (back);
-	return back;
+struct list_elem *list_pop_back(struct list *list) {
+    struct list_elem *back = list_back(list);
+    list_remove(back);
+    return back;
 }
 
 /* Returns the front element in LIST.
    Undefined behavior if LIST is empty. */
-struct list_elem *
-list_front (struct list *list) {
-	ASSERT (!list_empty (list));
-	return list->head.next;
+struct list_elem *list_front(struct list *list) {
+    ASSERT(!list_empty(list));
+    return list->head.next;
 }
 
 /* Returns the back element in LIST.
    Undefined behavior if LIST is empty. */
-struct list_elem *
-list_back (struct list *list) {
-	ASSERT (!list_empty (list));
-	return list->tail.prev;
+struct list_elem *list_back(struct list *list) {
+    ASSERT(!list_empty(list));
+    return list->tail.prev;
 }
 
 /* Returns the number of elements in LIST.
    Runs in O(n) in the number of elements. */
-size_t
-list_size (struct list *list) {
-	struct list_elem *e;
-	size_t cnt = 0;
+size_t list_size(struct list *list) {
+    struct list_elem *e;
+    size_t cnt = 0;
 
-	for (e = list_begin (list); e != list_end (list); e = list_next (e))
-		cnt++;
-	return cnt;
+    for (e = list_begin(list); e != list_end(list); e = list_next(e))
+        cnt++;
+    return cnt;
 }
 
 /* Returns true if LIST is empty, false otherwise. */
-bool
-list_empty (struct list *list) {
-	return list_begin (list) == list_end (list);
-}
+bool list_empty(struct list *list) { return list_begin(list) == list_end(list); }
 
 /* Swaps the `struct list_elem *'s that A and B point to. */
-static void
-swap (struct list_elem **a, struct list_elem **b) {
-	struct list_elem *t = *a;
-	*a = *b;
-	*b = t;
+static void swap(struct list_elem **a, struct list_elem **b) {
+    struct list_elem *t = *a;
+    *a = *b;
+    *b = t;
 }
 
 /* Reverses the order of LIST. */
-void
-list_reverse (struct list *list) {
-	if (!list_empty (list)) {
-		struct list_elem *e;
+void list_reverse(struct list *list) {
+    if (!list_empty(list)) {
+        struct list_elem *e;
 
-		for (e = list_begin (list); e != list_end (list); e = e->prev)
-			swap (&e->prev, &e->next);
-		swap (&list->head.next, &list->tail.prev);
-		swap (&list->head.next->prev, &list->tail.prev->next);
-	}
+        for (e = list_begin(list); e != list_end(list); e = e->prev)
+            swap(&e->prev, &e->next);
+        swap(&list->head.next, &list->tail.prev);
+        swap(&list->head.next->prev, &list->tail.prev->next);
+    }
 }
 
 /* Returns true only if the list elements A through B (exclusive)
    are in order according to LESS given auxiliary data AUX. */
-static bool
-is_sorted (struct list_elem *a, struct list_elem *b,
-		list_less_func *less, void *aux) {
-	if (a != b)
-		while ((a = list_next (a)) != b)
-			if (less (a, list_prev (a), aux))
-				return false;
-	return true;
+static bool is_sorted(struct list_elem *a, struct list_elem *b, list_less_func *less, void *aux) {
+    if (a != b)
+        while ((a = list_next(a)) != b)
+            if (less(a, list_prev(a), aux))
+                return false;
+    return true;
 }
 
 /* Finds a run, starting at A and ending not after B, of list
@@ -335,18 +295,16 @@ is_sorted (struct list_elem *a, struct list_elem *b,
    given auxiliary data AUX.  Returns the (exclusive) end of the
    run.
    A through B (exclusive) must form a non-empty range. */
-static struct list_elem *
-find_end_of_run (struct list_elem *a, struct list_elem *b,
-		list_less_func *less, void *aux) {
-	ASSERT (a != NULL);
-	ASSERT (b != NULL);
-	ASSERT (less != NULL);
-	ASSERT (a != b);
+static struct list_elem *find_end_of_run(struct list_elem *a, struct list_elem *b, list_less_func *less, void *aux) {
+    ASSERT(a != NULL);
+    ASSERT(b != NULL);
+    ASSERT(less != NULL);
+    ASSERT(a != b);
 
-	do {
-		a = list_next (a);
-	} while (a != b && !less (a, list_prev (a), aux));
-	return a;
+    do {
+        a = list_next(a);
+    } while (a != b && !less(a, list_prev(a), aux));
+    return a;
 }
 
 /* Merges A0 through A1B0 (exclusive) with A1B0 through B1
@@ -354,136 +312,127 @@ find_end_of_run (struct list_elem *a, struct list_elem *b,
    (exclusive).  Both input ranges must be nonempty and sorted in
    nondecreasing order according to LESS given auxiliary data
    AUX.  The output range will be sorted the same way. */
-static void
-inplace_merge (struct list_elem *a0, struct list_elem *a1b0,
-		struct list_elem *b1,
-		list_less_func *less, void *aux) {
-	ASSERT (a0 != NULL);
-	ASSERT (a1b0 != NULL);
-	ASSERT (b1 != NULL);
-	ASSERT (less != NULL);
-	ASSERT (is_sorted (a0, a1b0, less, aux));
-	ASSERT (is_sorted (a1b0, b1, less, aux));
+static void inplace_merge(struct list_elem *a0, struct list_elem *a1b0, struct list_elem *b1, list_less_func *less,
+                          void *aux) {
+    ASSERT(a0 != NULL);
+    ASSERT(a1b0 != NULL);
+    ASSERT(b1 != NULL);
+    ASSERT(less != NULL);
+    ASSERT(is_sorted(a0, a1b0, less, aux));
+    ASSERT(is_sorted(a1b0, b1, less, aux));
 
-	while (a0 != a1b0 && a1b0 != b1)
-		if (!less (a1b0, a0, aux))
-			a0 = list_next (a0);
-		else {
-			a1b0 = list_next (a1b0);
-			list_splice (a0, list_prev (a1b0), a1b0);
-		}
+    while (a0 != a1b0 && a1b0 != b1)
+        if (!less(a1b0, a0, aux))
+            a0 = list_next(a0);
+        else {
+            a1b0 = list_next(a1b0);
+            list_splice(a0, list_prev(a1b0), a1b0);
+        }
 }
 
 /* Sorts LIST according to LESS given auxiliary data AUX, using a
    natural iterative merge sort that runs in O(n lg n) time and
    O(1) space in the number of elements in LIST. */
-void
-list_sort (struct list *list, list_less_func *less, void *aux) {
-	size_t output_run_cnt;        /* Number of runs output in current pass. */
+void list_sort(struct list *list, list_less_func *less, void *aux) {
+    size_t output_run_cnt; /* Number of runs output in current pass. */
 
-	ASSERT (list != NULL);
-	ASSERT (less != NULL);
+    ASSERT(list != NULL);
+    ASSERT(less != NULL);
 
-	/* Pass over the list repeatedly, merging adjacent runs of
-	   nondecreasing elements, until only one run is left. */
-	do {
-		struct list_elem *a0;     /* Start of first run. */
-		struct list_elem *a1b0;   /* End of first run, start of second. */
-		struct list_elem *b1;     /* End of second run. */
+    /* Pass over the list repeatedly, merging adjacent runs of
+       nondecreasing elements, until only one run is left. */
+    do {
+        struct list_elem *a0;   /* Start of first run. */
+        struct list_elem *a1b0; /* End of first run, start of second. */
+        struct list_elem *b1;   /* End of second run. */
 
-		output_run_cnt = 0;
-		for (a0 = list_begin (list); a0 != list_end (list); a0 = b1) {
-			/* Each iteration produces one output run. */
-			output_run_cnt++;
+        output_run_cnt = 0;
+        for (a0 = list_begin(list); a0 != list_end(list); a0 = b1) {
+            /* Each iteration produces one output run. */
+            output_run_cnt++;
 
-			/* Locate two adjacent runs of nondecreasing elements
-			   A0...A1B0 and A1B0...B1. */
-			a1b0 = find_end_of_run (a0, list_end (list), less, aux);
-			if (a1b0 == list_end (list))
-				break;
-			b1 = find_end_of_run (a1b0, list_end (list), less, aux);
+            /* Locate two adjacent runs of nondecreasing elements
+               A0...A1B0 and A1B0...B1. */
+            a1b0 = find_end_of_run(a0, list_end(list), less, aux);
+            if (a1b0 == list_end(list))
+                break;
+            b1 = find_end_of_run(a1b0, list_end(list), less, aux);
 
-			/* Merge the runs. */
-			inplace_merge (a0, a1b0, b1, less, aux);
-		}
-	}
-	while (output_run_cnt > 1);
+            /* Merge the runs. */
+            inplace_merge(a0, a1b0, b1, less, aux);
+        }
+    } while (output_run_cnt > 1);
 
-	ASSERT (is_sorted (list_begin (list), list_end (list), less, aux));
+    ASSERT(is_sorted(list_begin(list), list_end(list), less, aux));
 }
 
-/* Inserts ELEM in the proper position in LIST, which must be
-   sorted according to LESS given auxiliary data AUX.
-   Runs in O(n) average case in the number of elements in LIST. */
-void
-list_insert_ordered (struct list *list, struct list_elem *elem,
-		list_less_func *less, void *aux) {
-	struct list_elem *e;
+/* ELEM을 LIST의 적절한 위치에 삽입합니다. LIST는 AUX를 보조 데이터로 사용하는 
+   LESS 함수에 따라 정렬되어 있어야 합니다.
+   LIST의 요소 수에 대해 평균적으로 O(n)의 시간복잡도를 가집니다. */
+void list_insert_ordered(struct list *list, struct list_elem *elem, list_less_func *less, void *aux) {
+    struct list_elem *e; // 리스트의 요소를 가리키는 포인터
 
-	ASSERT (list != NULL);
-	ASSERT (elem != NULL);
-	ASSERT (less != NULL);
+    ASSERT(list != NULL); // list가 NULL이 아님
+    ASSERT(elem != NULL); // elem이 NULL이 아님
+    ASSERT(less != NULL); // less가 NULL이 아님
 
-	for (e = list_begin (list); e != list_end (list); e = list_next (e))
-		if (less (elem, e, aux))
-			break;
-	return list_insert (e, elem);
+    for (e = list_begin(list); e != list_end(list); e = list_next(e))
+        if (less(elem, e, aux)) // elem이 e보다 작으면
+            break; // 반복문 종료
+
+    return list_insert(e, elem); // e 바로 앞에 elem 삽입
 }
 
 /* Iterates through LIST and removes all but the first in each
    set of adjacent elements that are equal according to LESS
    given auxiliary data AUX.  If DUPLICATES is non-null, then the
    elements from LIST are appended to DUPLICATES. */
-void
-list_unique (struct list *list, struct list *duplicates,
-		list_less_func *less, void *aux) {
-	struct list_elem *elem, *next;
+void list_unique(struct list *list, struct list *duplicates, list_less_func *less, void *aux) {
+    struct list_elem *elem, *next;
 
-	ASSERT (list != NULL);
-	ASSERT (less != NULL);
-	if (list_empty (list))
-		return;
+    ASSERT(list != NULL);
+    ASSERT(less != NULL);
+    if (list_empty(list))
+        return;
 
-	elem = list_begin (list);
-	while ((next = list_next (elem)) != list_end (list))
-		if (!less (elem, next, aux) && !less (next, elem, aux)) {
-			list_remove (next);
-			if (duplicates != NULL)
-				list_push_back (duplicates, next);
-		} else
-			elem = next;
+    elem = list_begin(list);
+    while ((next = list_next(elem)) != list_end(list))
+        if (!less(elem, next, aux) && !less(next, elem, aux)) {
+            list_remove(next);
+            if (duplicates != NULL)
+                list_push_back(duplicates, next);
+        } else
+            elem = next;
 }
 
 /* Returns the element in LIST with the largest value according
    to LESS given auxiliary data AUX.  If there is more than one
    maximum, returns the one that appears earlier in the list.  If
    the list is empty, returns its tail. */
-struct list_elem *
-list_max (struct list *list, list_less_func *less, void *aux) {
-	struct list_elem *max = list_begin (list);
-	if (max != list_end (list)) {
-		struct list_elem *e;
+struct list_elem *list_max(struct list *list, list_less_func *less, void *aux) {
+    struct list_elem *max = list_begin(list);
+    if (max != list_end(list)) {
+        struct list_elem *e;
 
-		for (e = list_next (max); e != list_end (list); e = list_next (e))
-			if (less (max, e, aux))
-				max = e;
-	}
-	return max;
+        for (e = list_next(max); e != list_end(list); e = list_next(e))
+            if (less(max, e, aux))
+                max = e;
+    }
+    return max;
 }
 
 /* Returns the element in LIST with the smallest value according
    to LESS given auxiliary data AUX.  If there is more than one
    minimum, returns the one that appears earlier in the list.  If
    the list is empty, returns its tail. */
-struct list_elem *
-list_min (struct list *list, list_less_func *less, void *aux) {
-	struct list_elem *min = list_begin (list);
-	if (min != list_end (list)) {
-		struct list_elem *e;
+struct list_elem *list_min(struct list *list, list_less_func *less, void *aux) {
+    struct list_elem *min = list_begin(list);
+    if (min != list_end(list)) {
+        struct list_elem *e;
 
-		for (e = list_next (min); e != list_end (list); e = list_next (e))
-			if (less (e, min, aux))
-				min = e;
-	}
-	return min;
+        for (e = list_next(min); e != list_end(list); e = list_next(e))
+            if (less(e, min, aux))
+                min = e;
+    }
+    return min;
 }

--- a/threads/palloc.c
+++ b/threads/palloc.c
@@ -284,13 +284,12 @@ palloc_get_multiple (enum palloc_flags flags, size_t page_cnt) {
 	return pages;
 }
 
-/* Obtains a single free page and returns its kernel virtual
-   address.
-   If PAL_USER is set, the page is obtained from the user pool,
-   otherwise from the kernel pool.  If PAL_ZERO is set in FLAGS,
-   then the page is filled with zeros.  If no pages are
-   available, returns a null pointer, unless PAL_ASSERT is set in
-   FLAGS, in which case the kernel panics. */
+/* 단일 빈 페이지를 할당받아 해당 페이지의 커널 가상 주소를 반환합니다.
+   PAL_USER 플래그가 설정된 경우 사용자 풀에서 페이지를 할당받고,
+   그렇지 않으면 커널 풀에서 할당받습니다. PAL_ZERO 플래그가 설정된 경우
+   할당된 페이지를 0으로 초기화합니다. 사용 가능한 페이지가 없는 경우
+   NULL을 반환하지만, PAL_ASSERT 플래그가 설정된 경우에는 커널 패닉을 
+   발생시킵니다. */
 void *
 palloc_get_page (enum palloc_flags flags) {
 	return palloc_get_multiple (flags, 1);

--- a/threads/synch.c
+++ b/threads/synch.c
@@ -27,10 +27,12 @@
    */
 
 #include "threads/synch.h"
-#include <stdio.h>
-#include <string.h>
 #include "threads/interrupt.h"
 #include "threads/thread.h"
+#include <stdio.h>
+#include <string.h>
+
+bool sema_compare_priority(const struct list_elem *l, const struct list_elem *s, void *aux UNUSED);
 
 /* Initializes semaphore SEMA to VALUE.  A semaphore is a
    nonnegative integer along with two atomic operators for
@@ -41,116 +43,108 @@
 
    - up or "V": increment the value (and wake up one waiting
    thread, if any). */
-void
-sema_init (struct semaphore *sema, unsigned value) {
-	ASSERT (sema != NULL);
+void sema_init(struct semaphore *sema, unsigned value) {
+    ASSERT(sema != NULL);
 
-	sema->value = value;
-	list_init (&sema->waiters);
+    sema->value = value;
+    list_init(&sema->waiters);
 }
 
-/* Down or "P" operation on a semaphore.  Waits for SEMA's value
-   to become positive and then atomically decrements it.
+/* 세마포어에 대한 다운(Down) 또는 "P" 연산입니다. 세마포어의 값이 양수가 될 때까지
+   대기한 후 원자적으로 값을 감소시킵니다.
 
-   This function may sleep, so it must not be called within an
-   interrupt handler.  This function may be called with
-   interrupts disabled, but if it sleeps then the next scheduled
-   thread will probably turn interrupts back on. This is
-   sema_down function. */
-void
-sema_down (struct semaphore *sema) {
-	enum intr_level old_level;
+   이 함수는 슬립 상태가 될 수 있으므로 인터럽트 핸들러 내에서 호출되어서는 안 됩니다.
+   인터럽트가 비활성화된 상태에서 호출될 수 있지만, 만약 슬립 상태가 되면
+   다음에 스케줄링되는 스레드가 인터럽트를 다시 활성화할 것입니다.
+   이것이 sema_down 함수입니다. */
+void sema_down(struct semaphore *sema) {
+    enum intr_level old_level; // 인터럽트 레벨 변수 선언
 
-	ASSERT (sema != NULL);
-	ASSERT (!intr_context ());
+    ASSERT(sema != NULL);    // 세마포어가 NULL이 아닌지 검사
+    ASSERT(!intr_context()); // 인터럽트 컨텍스트인지 검사
 
-	old_level = intr_disable ();
-	while (sema->value == 0) {
-		list_push_back (&sema->waiters, &thread_current ()->elem);
-		thread_block ();
-	}
-	sema->value--;
-	intr_set_level (old_level);
+    old_level = intr_disable(); // 인터럽트 비활성화
+    while (sema->value == 0) {
+        list_insert_ordered(&sema->waiters, &thread_current()->elem, compare_priority,
+                            0); // 현재 스레드를 세마포어의 대기 목록에 내림차순으로 삽입
+        thread_block();         // 현재 스레드를 블록 상태로 전환
+    }
+    sema->value--;             // 세마포어 값 감소
+    intr_set_level(old_level); // 인터럽트 레벨 복원
 }
 
-/* Down or "P" operation on a semaphore, but only if the
-   semaphore is not already 0.  Returns true if the semaphore is
-   decremented, false otherwise.
+/* 세마포어에 대한 다운(Down) 또는 "P" 연산을 수행하지만, 세마포어 값이 이미 0이 아닌
+   경우에만 수행합니다. 세마포어 값이 감소되면 true를 반환하고, 그렇지 않으면 false를
+   반환합니다.
 
-   This function may be called from an interrupt handler. */
-bool
-sema_try_down (struct semaphore *sema) {
-	enum intr_level old_level;
-	bool success;
+   이 함수는 인터럽트 핸들러에서 호출될 수 있습니다. */
+bool sema_try_down(struct semaphore *sema) {
+    enum intr_level old_level;
+    bool success;
 
-	ASSERT (sema != NULL);
+    ASSERT(sema != NULL);
 
-	old_level = intr_disable ();
-	if (sema->value > 0)
-	{
-		sema->value--;
-		success = true;
-	}
-	else
-		success = false;
-	intr_set_level (old_level);
+    old_level = intr_disable();
+    if (sema->value > 0) {
+        sema->value--;
+        success = true;
+    } else
+        success = false;
+    intr_set_level(old_level);
 
-	return success;
+    return success;
 }
 
-/* Up or "V" operation on a semaphore.  Increments SEMA's value
-   and wakes up one thread of those waiting for SEMA, if any.
+/* 세마포어에 대한 업(Up) 또는 "V" 연산입니다. 세마포어의 값을 증가시키고,
+   세마포어를 기다리는 스레드가 있다면 그 중 하나를 깨웁니다.
 
-   This function may be called from an interrupt handler. */
-void
-sema_up (struct semaphore *sema) {
-	enum intr_level old_level;
+   이 함수는 인터럽트 핸들러 내에서 호출될 수 있습니다. */
+void sema_up(struct semaphore *sema) {
+    enum intr_level old_level; // 인터럽트 레벨 변수 선언
 
-	ASSERT (sema != NULL);
+    ASSERT(sema != NULL); // 세마포어가 NULL이 아닌지 검사
 
-	old_level = intr_disable ();
-	if (!list_empty (&sema->waiters))
-		thread_unblock (list_entry (list_pop_front (&sema->waiters),
-					struct thread, elem));
-	sema->value++;
-	intr_set_level (old_level);
+    old_level = intr_disable();                         // 인터럽트 비활성화
+    if (!list_empty(&sema->waiters)) {                  // 세마포어의 대기 목록이 비어있지 않으면
+        list_sort(&sema->waiters, compare_priority, 0); // 대기 목록을 우선순위에 따라 정렬
+        thread_unblock(list_entry(list_pop_front(&sema->waiters), struct thread, elem)); // 가장 앞에 있는 스레드를 깨움
+    }
+    sema->value++;             // 세마포어 값 증가
+    thread_preemption();      // 선점 활성화
+    intr_set_level(old_level); // 인터럽트 레벨 복원
 }
 
-static void sema_test_helper (void *sema_);
+static void sema_test_helper(void *sema_);
 
 /* Self-test for semaphores that makes control "ping-pong"
    between a pair of threads.  Insert calls to printf() to see
    what's going on. */
-void
-sema_self_test (void) {
-	struct semaphore sema[2];
-	int i;
+void sema_self_test(void) {
+    struct semaphore sema[2];
+    int i;
 
-	printf ("Testing semaphores...");
-	sema_init (&sema[0], 0);
-	sema_init (&sema[1], 0);
-	thread_create ("sema-test", PRI_DEFAULT, sema_test_helper, &sema);
-	for (i = 0; i < 10; i++)
-	{
-		sema_up (&sema[0]);
-		sema_down (&sema[1]);
-	}
-	printf ("done.\n");
+    printf("Testing semaphores...");
+    sema_init(&sema[0], 0);
+    sema_init(&sema[1], 0);
+    thread_create("sema-test", PRI_DEFAULT, sema_test_helper, &sema);
+    for (i = 0; i < 10; i++) {
+        sema_up(&sema[0]);
+        sema_down(&sema[1]);
+    }
+    printf("done.\n");
 }
 
 /* Thread function used by sema_self_test(). */
-static void
-sema_test_helper (void *sema_) {
-	struct semaphore *sema = sema_;
-	int i;
+static void sema_test_helper(void *sema_) {
+    struct semaphore *sema = sema_;
+    int i;
 
-	for (i = 0; i < 10; i++)
-	{
-		sema_down (&sema[0]);
-		sema_up (&sema[1]);
-	}
+    for (i = 0; i < 10; i++) {
+        sema_down(&sema[0]);
+        sema_up(&sema[1]);
+    }
 }
-
+
 /* Initializes LOCK.  A lock can be held by at most a single
    thread at any given time.  Our locks are not "recursive", that
    is, it is an error for the thread currently holding a lock to
@@ -166,12 +160,11 @@ sema_test_helper (void *sema_) {
    acquire and release it.  When these restrictions prove
    onerous, it's a good sign that a semaphore should be used,
    instead of a lock. */
-void
-lock_init (struct lock *lock) {
-	ASSERT (lock != NULL);
+void lock_init(struct lock *lock) {
+    ASSERT(lock != NULL);
 
-	lock->holder = NULL;
-	sema_init (&lock->semaphore, 1);
+    lock->holder = NULL;
+    sema_init(&lock->semaphore, 1);
 }
 
 /* Acquires LOCK, sleeping until it becomes available if
@@ -182,14 +175,13 @@ lock_init (struct lock *lock) {
    interrupt handler.  This function may be called with
    interrupts disabled, but interrupts will be turned back on if
    we need to sleep. */
-void
-lock_acquire (struct lock *lock) {
-	ASSERT (lock != NULL);
-	ASSERT (!intr_context ());
-	ASSERT (!lock_held_by_current_thread (lock));
+void lock_acquire(struct lock *lock) {
+    ASSERT(lock != NULL);
+    ASSERT(!intr_context());
+    ASSERT(!lock_held_by_current_thread(lock));
 
-	sema_down (&lock->semaphore);
-	lock->holder = thread_current ();
+    sema_down(&lock->semaphore);
+    lock->holder = thread_current();
 }
 
 /* Tries to acquires LOCK and returns true if successful or false
@@ -198,17 +190,16 @@ lock_acquire (struct lock *lock) {
 
    This function will not sleep, so it may be called within an
    interrupt handler. */
-bool
-lock_try_acquire (struct lock *lock) {
-	bool success;
+bool lock_try_acquire(struct lock *lock) {
+    bool success;
 
-	ASSERT (lock != NULL);
-	ASSERT (!lock_held_by_current_thread (lock));
+    ASSERT(lock != NULL);
+    ASSERT(!lock_held_by_current_thread(lock));
 
-	success = sema_try_down (&lock->semaphore);
-	if (success)
-		lock->holder = thread_current ();
-	return success;
+    success = sema_try_down(&lock->semaphore);
+    if (success)
+        lock->holder = thread_current();
+    return success;
 }
 
 /* Releases LOCK, which must be owned by the current thread.
@@ -217,107 +208,114 @@ lock_try_acquire (struct lock *lock) {
    An interrupt handler cannot acquire a lock, so it does not
    make sense to try to release a lock within an interrupt
    handler. */
-void
-lock_release (struct lock *lock) {
-	ASSERT (lock != NULL);
-	ASSERT (lock_held_by_current_thread (lock));
+void lock_release(struct lock *lock) {
+    ASSERT(lock != NULL);
+    ASSERT(lock_held_by_current_thread(lock));
 
-	lock->holder = NULL;
-	sema_up (&lock->semaphore);
+    lock->holder = NULL;
+    sema_up(&lock->semaphore);
 }
 
 /* Returns true if the current thread holds LOCK, false
    otherwise.  (Note that testing whether some other thread holds
    a lock would be racy.) */
-bool
-lock_held_by_current_thread (const struct lock *lock) {
-	ASSERT (lock != NULL);
+bool lock_held_by_current_thread(const struct lock *lock) {
+    ASSERT(lock != NULL);
 
-	return lock->holder == thread_current ();
+    return lock->holder == thread_current();
 }
-
+
 /* One semaphore in a list. */
 struct semaphore_elem {
-	struct list_elem elem;              /* List element. */
-	struct semaphore semaphore;         /* This semaphore. */
+    struct list_elem elem;      /* List element. */
+    struct semaphore semaphore; /* This semaphore. */
 };
 
 /* Initializes condition variable COND.  A condition variable
    allows one piece of code to signal a condition and cooperating
    code to receive the signal and act upon it. */
-void
-cond_init (struct condition *cond) {
-	ASSERT (cond != NULL);
+void cond_init(struct condition *cond) {
+    ASSERT(cond != NULL);
 
-	list_init (&cond->waiters);
+    list_init(&cond->waiters);
 }
 
-/* Atomically releases LOCK and waits for COND to be signaled by
-   some other piece of code.  After COND is signaled, LOCK is
-   reacquired before returning.  LOCK must be held before calling
-   this function.
+/* 원자적으로 LOCK을 해제하고 다른 코드에 의해 COND가 시그널될 때까지 대기합니다.
+   COND가 시그널되면 반환하기 전에 LOCK을 다시 획득합니다.
+   이 함수를 호출하기 전에는 반드시 LOCK을 보유하고 있어야 합니다.
 
-   The monitor implemented by this function is "Mesa" style, not
-   "Hoare" style, that is, sending and receiving a signal are not
-   an atomic operation.  Thus, typically the caller must recheck
-   the condition after the wait completes and, if necessary, wait
-   again.
+   이 함수로 구현된 모니터는 "Hoare" 스타일이 아닌 "Mesa" 스타일입니다.
+   즉, 시그널을 보내고 받는 것이 원자적 연산이 아닙니다.
+   따라서 일반적으로 호출자는 대기가 완료된 후 조건을 다시 확인해야 하며,
+   필요한 경우 다시 대기해야 합니다.
 
-   A given condition variable is associated with only a single
-   lock, but one lock may be associated with any number of
-   condition variables.  That is, there is a one-to-many mapping
-   from locks to condition variables.
+   하나의 조건 변수는 단 하나의 락과만 연관되지만,
+   하나의 락은 여러 개의 조건 변수와 연관될 수 있습니다.
+   즉, 락에서 조건 변수로의 일대다 매핑이 존재합니다.
 
-   This function may sleep, so it must not be called within an
-   interrupt handler.  This function may be called with
-   interrupts disabled, but interrupts will be turned back on if
-   we need to sleep. */
-void
-cond_wait (struct condition *cond, struct lock *lock) {
-	struct semaphore_elem waiter;
+   이 함수는 슬립 상태가 될 수 있으므로 인터럽트 핸들러 내에서 호출되어서는 안 됩니다.
+   인터럽트가 비활성화된 상태에서 이 함수를 호출할 수 있지만,
+   슬립이 필요한 경우 인터럽트가 다시 활성화됩니다. */
+void cond_wait(struct condition *cond, struct lock *lock) {
+    struct semaphore_elem waiter;
 
-	ASSERT (cond != NULL);
-	ASSERT (lock != NULL);
-	ASSERT (!intr_context ());
-	ASSERT (lock_held_by_current_thread (lock));
+    ASSERT(cond != NULL);                      // cond가 NULL이 아닌지 검사
+    ASSERT(lock != NULL);                      // lock이 NULL이 아닌지 검사
+    ASSERT(!intr_context());                   // 인터럽트 컨텍스트인지 검사
+    ASSERT(lock_held_by_current_thread(lock)); // lock을 현재 스레드가 보유하고 있는지 검사
 
-	sema_init (&waiter.semaphore, 0);
-	list_push_back (&cond->waiters, &waiter.elem);
-	lock_release (lock);
-	sema_down (&waiter.semaphore);
-	lock_acquire (lock);
+    sema_init(&waiter.semaphore, 0); // waiter의 세마포어 초기화
+    list_insert_ordered(&cond->waiters, &waiter.elem, sema_compare_priority,
+                        0);       // waiter를 대기 목록에 내림차순으로 삽입
+    lock_release(lock);           // lock 해제
+    sema_down(&waiter.semaphore); // waiter의 세마포어 다운
+    lock_acquire(lock);           // lock 획득
 }
 
-/* If any threads are waiting on COND (protected by LOCK), then
-   this function signals one of them to wake up from its wait.
-   LOCK must be held before calling this function.
+/* COND에서 대기 중인 스레드가 있다면(LOCK으로 보호됨),
+   이 함수는 그 중 하나에게 대기 상태에서 깨어나라는 시그널을 보냅니다.
+   이 함수를 호출하기 전에는 반드시 LOCK을 보유하고 있어야 합니다.
 
-   An interrupt handler cannot acquire a lock, so it does not
-   make sense to try to signal a condition variable within an
-   interrupt handler. */
-void
-cond_signal (struct condition *cond, struct lock *lock UNUSED) {
-	ASSERT (cond != NULL);
-	ASSERT (lock != NULL);
-	ASSERT (!intr_context ());
-	ASSERT (lock_held_by_current_thread (lock));
+   인터럽트 핸들러는 락을 획득할 수 없으므로,
+   인터럽트 핸들러 내에서 조건 변수에 시그널을 보내는 것은 의미가 없습니다. */
+void cond_signal(struct condition *cond, struct lock *lock UNUSED) {
+    ASSERT(cond != NULL);                      // cond가 NULL이 아닌지 검사
+    ASSERT(lock != NULL);                      // lock이 NULL이 아닌지 검사
+    ASSERT(!intr_context());                   // 인터럽트 컨텍스트인지 검사
+    ASSERT(lock_held_by_current_thread(lock)); // lock을 현재 스레드가 보유하고 있는지 검사
 
-	if (!list_empty (&cond->waiters))
-		sema_up (&list_entry (list_pop_front (&cond->waiters),
-					struct semaphore_elem, elem)->semaphore);
+    if (!list_empty(&cond->waiters)) {                       // 대기 목록이 비어있지 않으면
+        list_sort(&cond->waiters, sema_compare_priority, 0); // 대기 목록을 우선순위에 따라 정렬
+        sema_up(&list_entry(list_pop_front(&cond->waiters), struct semaphore_elem, elem)
+                     ->semaphore); // 가장 앞에 있는 스레드의 세마포어 업
+    }
 }
 
-/* Wakes up all threads, if any, waiting on COND (protected by
-   LOCK).  LOCK must be held before calling this function.
+/* COND에서 대기 중인 모든 스레드를 깨웁니다(LOCK으로 보호됨).
+   이 함수를 호출하기 전에는 반드시 LOCK을 보유하고 있어야 합니다.
 
-   An interrupt handler cannot acquire a lock, so it does not
-   make sense to try to signal a condition variable within an
-   interrupt handler. */
-void
-cond_broadcast (struct condition *cond, struct lock *lock) {
-	ASSERT (cond != NULL);
-	ASSERT (lock != NULL);
+   인터럽트 핸들러는 락을 획득할 수 없으므로,
+   인터럽트 핸들러 내에서 조건 변수에 시그널을 보내는 것은 의미가 없습니다. */
+void cond_broadcast(struct condition *cond, struct lock *lock) {
+    ASSERT(cond != NULL);                      // cond가 NULL이 아닌지 검사
+    ASSERT(lock != NULL);                      // lock이 NULL이 아닌지 검사
+    ASSERT(!intr_context());                   // 인터럽트 컨텍스트인지 검사
+    ASSERT(lock_held_by_current_thread(lock)); // lock을 현재 스레드가 보유하고 있는지 검사
 
-	while (!list_empty (&cond->waiters))
-		cond_signal (cond, lock);
+    while (!list_empty(&cond->waiters)) // 대기 목록이 비어있지 않으면
+        cond_signal(cond, lock);        // 대기 목록에 있는 모든 스레드에게 시그널 보냄
+}
+
+/* 세마포어의 대기 목록에서 스레드의 우선순위를 비교하는 함수 */
+bool sema_compare_priority(const struct list_elem *l, const struct list_elem *s, void *aux UNUSED) {
+    struct semaphore_elem *l_sema = list_entry(l, struct semaphore_elem, elem); // l 요소를 semaphore_elem 구조체로 변환
+    struct semaphore_elem *s_sema = list_entry(s, struct semaphore_elem, elem); // s 요소를 semaphore_elem 구조체로 변환
+
+    struct list *waiter_l_sema = &(l_sema->semaphore.waiters); // l_sema의 대기 목록
+    struct list *waiter_s_sema = &(s_sema->semaphore.waiters); // s_sema의 대기 목록
+
+    return list_entry(list_begin(waiter_l_sema), struct thread, elem)->priority >
+           list_entry(list_begin(waiter_s_sema), struct thread, elem)
+               ->priority; // l_sema의 대기 목록에서 첫 번째 스레드의 우선순위가 s_sema의 대기 목록에서 첫 번째 스레드의
+                           // 우선순위보다 높으면 true, 아니면 false 반환
 }


### PR DESCRIPTION
# 우선순위 스케쥴링 구현

세마포어와 조건변수의 대기 목록을 우선순위 기반으로 관리하도록 개선했습니다.

주요 변경사항:
- sema_down(): 대기 목록에 스레드를 우선순위 순서로 삽입
- sema_up(): 대기 목록을 우선순위에 따라 정렬하고 가장 높은 우선순위의 스레드를 깨움
- cond_wait(): 조건변수 대기 목록에 우선순위 순서로 삽입
- cond_signal(): 대기 목록을 우선순위에 따라 정렬하고 가장 높은 우선순위의 스레드에게 시그널
- sema_compare_priority(): 세마포어 대기 목록의 스레드 우선순위 비교 함수 추가

이를 통해:
1. 우선순위가 높은 스레드가 먼저 깨어나도록 보장
2. 우선순위 역전 현상 방지
3. 전반적인 스케줄링 효율성 향상